### PR TITLE
SOE-395: Add new function that sets JSE specific variables. Switch fo…

### DIFF
--- a/includes/JumpstartSitesEngineering.php
+++ b/includes/JumpstartSitesEngineering.php
@@ -93,6 +93,7 @@ class JumpstartSitesEngineering extends JumpstartSitesAcademic {
 
     // Variables.
     variable_set('stanford_jumpstart_engineering', TRUE);
+    variable_del('stanford_jumpstart_academic');
     drush_log('JSE - Finished Setting JSE Variables.', 'ok');
   }
   

--- a/includes/JumpstartSitesEngineering.php
+++ b/includes/JumpstartSitesEngineering.php
@@ -46,6 +46,14 @@ class JumpstartSitesEngineering extends JumpstartSitesAcademic {
       'function' => 'install_content',
       'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
     );
+    
+    $tasks['jse_set_jse_variables'] = array(
+        'display_name' => st('Install JSE needed variables'),
+        'display' => FALSE,
+        'type' => 'normal',
+        'function' => 'set_jse_variables',
+        'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
+    );
 
     $tasks['jse_install_pps_menu_items'] = array(
       'display_name' => st('Install private pages section menu items.'),
@@ -75,6 +83,19 @@ class JumpstartSitesEngineering extends JumpstartSitesAcademic {
     return array_merge($parent_tasks, $tasks);
   }
 
+  // Set Jumpstart Engineering Specific variables and settings
+  //
+  //
+  
+  public function set_jse_variables(&$install_state) {
+    drush_log('JSE - Setting JSE Specific Variables.', 'ok');
+
+
+    // Variables.
+    variable_set('stanford_jumpstart_engineering', TRUE);
+    drush_log('JSE - Finished Setting JSE Variables.', 'ok');
+  }
+  
   // Install tasks below.
   // //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This adds a new function that will set JSE specific variables on installation.  For now, the only variable_set is stanford_jumpstart_engineering = TRUE.  This allows for a switch for JSE specific functions.  Needed to satisfy SOE-395, changes to help pages. 
